### PR TITLE
Allow reset of Env.mock

### DIFF
--- a/dcli_core/lib/src/functions/env.dart
+++ b/dcli_core/lib/src/functions/env.dart
@@ -371,7 +371,7 @@ class Env extends DCliFunction {
 
   /// Used in unit tests to mock the Env class.
   // ignore: avoid_setters_without_getters
-  static set mock(Env mockEnv) {
+  static set mock(Env? mockEnv) {
     _self = mockEnv;
   }
 }


### PR DESCRIPTION
Allows

```dart
    Env.mock = Env();
    addTearDown(() {
      Env.mock = null;
    });
```